### PR TITLE
typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description='Package for time series analysis course at LTH',
     author='Filipp Lernbo',
     author_email='fi6418le-s@student.lu.se',
-    packages=['TSA'],
+    packages=['tsa_lth'],
     install_requires=[
         "filterpy==1.4.5",
         "matplotlib==3.7.1",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         "filterpy==1.4.5",
         "matplotlib==3.7.1",
-        "nfoursid==1.0.1"
+        "nfoursid==1.0.1",
         "pandas==2.1.0",
         "scipy==1.11.0",
         "statsmodels==0.14.0",


### PR DESCRIPTION
Found during installation

Potential typo 2 was giving this output: changing to  packages=['tsa_lth'], from packages=['TSA'] fixed issue.



Obtaining file:///home/labb3000/TimeSeriesAnalysis
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      running egg_info
      writing tsa_lth.egg-info/PKG-INFO
      writing dependency_links to tsa_lth.egg-info/dependency_links.txt
      writing requirements to tsa_lth.egg-info/requires.txt
      writing top-level names to tsa_lth.egg-info/top_level.txt
      error: package directory 'TSA' does not exist
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

